### PR TITLE
Remove redefinition of \BibTeX.

### DIFF
--- a/drexel-thesis.dtx
+++ b/drexel-thesis.dtx
@@ -171,7 +171,6 @@
 % \MakeShortVerb{\|}
 % \newcommand{\pkg}[1]{\textsf{#1}}
 % \newcommand{\cls}[1]{\textsf{#1}}
-% \newcommand{\BibTeX}{{\scshape Bib}\TeX}
 %
 % \title{The \textsf{drexel-thesis} class\thanks{This document
 %   corresponds to \textsf{drexel-thesis}~\fileversion, dated \filedate.}}


### PR DESCRIPTION
Fixes DrexelPhysics/drexel-thesis#4. \BibTeX is defined in
doc.sty, which is included by ltxdoc.cls.
